### PR TITLE
Correcting minor spelling error

### DIFF
--- a/cmapi-toc-1.2.0.json
+++ b/cmapi-toc-1.2.0.json
@@ -139,7 +139,7 @@
 		}]
 	}, {
 		"key": "",
-		"title": "Appendecies",
+		"title": "Appendices",
 		"expanded": true,
 		"folder": true,
 		"children": [{


### PR DESCRIPTION
Fixing spelling of 'Appendices'
