### PR TITLE
Deployement with surge

### DIFF
--- a/.surgeignore
+++ b/.surgeignore
@@ -1,0 +1,4 @@
+!dist
+node_modules
+src
+test

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=./docs/index.html"/>
+    <title>CMAPI</title>
+    <script>
+        window.location.href = "./docs/index.html";
+    </script>
+</head>
+<body>
+<p><a href="./docs/index.html">Documentation</a></p>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "cmapi",
   "version": "1.3.0",
+  "scripts": {
+    "build": "grunt",
+    "deploy": "surge -p ."
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-qunit": "^0.5.2",
     "grunt-contrib-uglify": "^0.6.0",
-    "grunt-contrib-watch": "^0.6.1"
+    "grunt-contrib-watch": "^0.6.1",
+    "surge": "^0.19.0"
   }
 }


### PR DESCRIPTION
Every one can easy change and send pull request to contribute cmapi by using github. This is great capability to collaborate. But reviewer should check out, build and read documentation to review each pull request or review by source code. With [surge](https://surge.sh)  (which I added to project with this PR) every one can deploy resulting documentation into cloud free. I think this capability makes easy to review contributions.