### PR TITLE
Need to update map.status.view

### DIFF
--- a/channels/cmapi.appendix.b.js
+++ b/channels/cmapi.appendix.b.js
@@ -72,7 +72,7 @@ cmapi.channel["cmapi.appendix.b"] = {
                     "maximum": 255
                   },
                   "b": {
-                    "description": "Integer value between 0 and 255 for green.",
+                    "description": "Integer value between 0 and 255 for blue.",
                     "type": "integer",
                     "minimum": 0,
                     "maximum": 255


### PR DESCRIPTION
map.status.view needs to be updated to support bounds as array to allow for IDL split on 2D maps which allow pan-zoom across IDL.

bounds - Bounding box of area visible on map which can contain up-to two map extents when map is view is split across International Date Line (IDL).
